### PR TITLE
Remove instanceof check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/react-shallow-renderer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/react-shallow-renderer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A shallow renderer for React components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {
   contextSymbol,
   elementSymbol,
@@ -37,8 +35,7 @@ export function isClass(node: ReactAnyNode): node is ReactClassNode {
   return (
     node.$$typeof === elementSymbol &&
     typeof node.type === 'function' &&
-    (node.type instanceof React.Component ||
-      (node.type.prototype && 'render' in node.type.prototype) ||
+    ((node.type.prototype && 'render' in node.type.prototype) ||
       MATCHES_CLASS.test(Object.toString.call(node.type)))
   );
 }

--- a/tests/to-json/component-class.tsx
+++ b/tests/to-json/component-class.tsx
@@ -199,5 +199,27 @@ describe('ReactShallowRenderer', () => {
         _store: {},
       });
     });
+
+    it("renders a component that is class-like, but doesn't inherit from component", () => {
+      function ClassLike() {
+        return null;
+      }
+
+      ClassLike.prototype.render = () => <p>Here's the bit we care about!</p>;
+
+      const renderer = new ReactShallowRenderer(<ClassLike />);
+
+      expect(renderer.toJSON()).toEqual({
+        $$typeof: elementSymbol,
+        type: 'p',
+        key: null,
+        ref: null,
+        props: {
+          children: ["Here's the bit we care about!"],
+        },
+        _owner: null,
+        _store: {},
+      });
+    });
   });
 });


### PR DESCRIPTION
Remove invalid `node.type instanceof React.Component` check (as type is not an instance, but a constructor), and test that rendering works with class-like functions (containing render methods).